### PR TITLE
Added an extra error message for when the command class doesn't exist.

### DIFF
--- a/src/App/CliApp.php
+++ b/src/App/CliApp.php
@@ -56,6 +56,9 @@ class CliApp extends AbstractApp
             if (!is_string($command)) {
                 throw new CommandException(sprintf('Command declaration must be a class name'));
             }
+            if (!class_exists($command)) {
+                throw new CommandException(sprintf('Command class "%s" not found', $command));
+            }
             if (!is_a($command, CommandInterface::class, true)) {
                 throw new CommandException(sprintf('Command class "%s" must be implement "%s" interface', $command, CommandInterface::class));
             }


### PR DESCRIPTION
Sometimes when you have a typo in your class name in your config file, having an error that tells you straight that the asked class doesn't exist is nice.